### PR TITLE
Making the ANSI escape regexes configurable in the Shell class

### DIFF
--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -37,6 +37,7 @@ except ImportError:
 from ansible.module_utils.basic import get_exception
 from ansible.module_utils.network import NetworkError
 
+# Default ANSI and terminal escape sequence regexes
 ANSI_RE = [
     re.compile(r'(\x1b\[\?1h\x1b=)'),
     re.compile(r'\x08.')
@@ -61,7 +62,7 @@ class ShellError(Exception):
 
 class Shell(object):
 
-    def __init__(self, prompts_re=None, errors_re=None, kickstart=True):
+    def __init__(self, prompts_re=None, errors_re=None, ansi_re=None, kickstart=True):
         self.ssh = None
         self.shell = None
 
@@ -70,6 +71,7 @@ class Shell(object):
 
         self.prompts = prompts_re or list()
         self.errors = errors_re or list()
+        self.ansi = ansi_re or ANSI_RE
 
     def open(self, host, port=22, username=None, password=None, timeout=10,
              key_filename=None, pkey=None, look_for_keys=None,
@@ -118,7 +120,7 @@ class Shell(object):
         self.receive()
 
     def strip(self, data):
-        for regex in ANSI_RE:
+        for regex in self.ansi:
             data = regex.sub('', data)
         return data
 
@@ -222,6 +224,7 @@ class CliBase(object):
                 kickstart=kickstart,
                 prompts_re=self.CLI_PROMPTS_RE,
                 errors_re=self.CLI_ERRORS_RE,
+                ansi_re=getattr(self, "CLI_ANSI_RE", ANSI_RE)
             )
             self.shell.open(
                 host, port=port, username=username, password=password,


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

Shell
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (shell_ansi_escape_fix a616dcbe1a) last updated 2016/10/12 11:54:17 (GMT -700)
  lib/ansible/modules/core: (detached HEAD b4f6a25195) last updated 2016/10/11 11:18:35 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 734aa8f8e9) last updated 2016/10/11 11:18:40 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

The module_utils Shell class uses a hardcoded set of regexes to filter out ansi color sequences and terminal escape codes.  For using the Shell with some network appliances, this set of regexes needs to be overridden (or expanded).

This change allows a CliBase subclass to override the ansi escape regexes in the same manner that it uses to provide the prompt and errors with CLI_PROMPTS_RE and CLI_ERRORS_RE.  This checks for a CLI_ANSI_RE, and if provided, uses that instead of the default ANSI_RE for sanitizing lines read from the remote shell.
